### PR TITLE
Update AI movement and sight range

### DIFF
--- a/Content/Data/DT_RoomDataTable.uasset
+++ b/Content/Data/DT_RoomDataTable.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a5f966ca295a8427f7c2edb26b54810091b6009fb5d42973e8e4f8cb6578949c
+oid sha256:beceb76ceeb1704466bc538f09ee650597751b691da9d5c33979d803666f8c57
 size 3821


### PR DESCRIPTION
- 기존 "적정 거리 이상일 때 이동 정지" 로직을 수정하여 AI가 고정된 위치에 있지 않도록 좌우로 작은 이동을 추가
- AI는 일정 시간마다 좌우로 반복 이동하여 플레이어의 겨냥을 어렵게 만드는 동작을 수행
- SineWave 방식을 사용하여 자연스러운 좌우 이동 패턴을 설정
- DT_RoomDataTable에서 각 레벨에 맞는 AI 시야 감지 범위(SightRadius, LoseSightRadius)를 공격 반경보다 넓게 업데이트
- Ranged Enemy의 공격 반경을 고려하여 AI 시야 감지 범위가 더 넓게 설정되도록 조정