### PR TITLE
Add debug visualization toggle for AI sight radius, attack radius, and bullet detection sphere

### DIFF
--- a/Source/Room/Private/AI/Controllers/EnemyAIController.cpp
+++ b/Source/Room/Private/AI/Controllers/EnemyAIController.cpp
@@ -83,6 +83,11 @@ AEnemyAIController::AEnemyAIController()
 	// 감지 이벤트가 발생했을 때 호출할 델리게이트 함수(OnTargetPerceptionUpdated)를 등록
 	// -> 대상 감지 시 or 시야에서 사라질 때 자동 호출됨
 	AIPerception->OnTargetPerceptionUpdated.AddDynamic(this, &AEnemyAIController::OnTargetPerceptionUpdated);
+
+	//======================================================
+	// 디버그용 시야/감지 상태 표시 여부 - 토글용 변수
+	//======================================================
+	bDrawDebug = false; // 기본값은 상태 표시 안 함
 }
 
 void AEnemyAIController::BeginPlay()

--- a/Source/Room/Private/Characters/MeleeEnemyCharacter.cpp
+++ b/Source/Room/Private/Characters/MeleeEnemyCharacter.cpp
@@ -46,6 +46,9 @@ AMeleeEnemyCharacter::AMeleeEnemyCharacter()
 	// 오버랩 이벤트 바인딩
 	BulletDetectionSphere->OnComponentBeginOverlap.AddDynamic(this, &AMeleeEnemyCharacter::OnBulletDetected);
 
+	// 디버그용 총알 감지 스피어 표시 여부 - 토글용 변수
+	bShowBulletDetectionSphere = false; // 기본값은 상태 표시 안 함
+
 	//======================================================
 	// 캐릭터가 속한 태그 추가
 	//======================================================
@@ -118,8 +121,8 @@ void AMeleeEnemyCharacter::BeginPlay()
 
 	if (BulletDetectionSphere)
 	{
-		BulletDetectionSphere->SetHiddenInGame(false);
-		BulletDetectionSphere->SetVisibility(true);
+		BulletDetectionSphere->SetHiddenInGame(!bShowBulletDetectionSphere);
+		BulletDetectionSphere->SetVisibility(bShowBulletDetectionSphere);
 	}
 	UE_LOG(LogTemp, Warning, TEXT("[AI][MeleeEnemyCharacter] AI Character has been spawned"));
 }

--- a/Source/Room/Private/Characters/RangedEnemyCharacter.cpp
+++ b/Source/Room/Private/Characters/RangedEnemyCharacter.cpp
@@ -46,6 +46,9 @@ ARangedEnemyCharacter::ARangedEnemyCharacter()
 	// 오버랩 이벤트 바인딩
 	BulletDetectionSphere->OnComponentBeginOverlap.AddDynamic(this, &ARangedEnemyCharacter::OnBulletDetected);
 
+	// 디버그용 총알 감지 스피어 표시 여부 - 토글용 변수
+	bShowBulletDetectionSphere = false; // 기본값은 상태 표시 안 함
+
 	//======================================================
 	// 캐릭터가 속한 태그 추가
 	//======================================================
@@ -118,8 +121,8 @@ void ARangedEnemyCharacter::BeginPlay()
 
 	if (BulletDetectionSphere)
 	{
-		BulletDetectionSphere->SetHiddenInGame(false);
-		BulletDetectionSphere->SetVisibility(true);
+		BulletDetectionSphere->SetHiddenInGame(!bShowBulletDetectionSphere);
+		BulletDetectionSphere->SetVisibility(bShowBulletDetectionSphere);
 	}
 	UE_LOG(LogTemp, Warning, TEXT("[AI] AI Character has been spawned"));
 }

--- a/Source/Room/Public/AI/Controllers/EnemyAIController.h
+++ b/Source/Room/Public/AI/Controllers/EnemyAIController.h
@@ -82,8 +82,9 @@ protected:
 	// 디버그 시각화용 타이머 핸들
 	FTimerHandle DebugDrawTimerHandle;
 
-	// 디버그용 시야/감지 상태 표시 여부 - 토글용 변수 (원하면 사용)
-	bool bDrawDebug = true;
+	// 디버그용 시야/감지 상태 표시 여부 - 토글용 변수
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AI|Debug")
+	bool bDrawDebug;
 
 private:
 	// 캐릭터를 기반으로 CombatType(근거리/원거리)을 블랙보드에 설정

--- a/Source/Room/Public/Characters/MeleeEnemyCharacter.h
+++ b/Source/Room/Public/Characters/MeleeEnemyCharacter.h
@@ -40,6 +40,10 @@ public:
 
 	// 달리기 속도 반환
 	virtual float GetRunSpeed() const override { return RunSpeed; }
+
+	// 디버그용 총알 감지 스피어 표시 여부 - 토글용 변수
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AI|Debug")
+	bool bShowBulletDetectionSphere;
 	
 protected:
 	// 근접 공격 컴포넌트

--- a/Source/Room/Public/Characters/RangedEnemyCharacter.h
+++ b/Source/Room/Public/Characters/RangedEnemyCharacter.h
@@ -41,6 +41,10 @@ public:
 	// 달리기 속도 반환
 	virtual float GetRunSpeed() const override { return RunSpeed; }
 
+	// 디버그용 총알 감지 스피어 표시 여부 - 토글용 변수
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AI|Debug")
+	bool bShowBulletDetectionSphere;
+
 protected:
 	// 원거리 공격 컴포넌트
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Attack")


### PR DESCRIPTION
- AIController에 시야 범위, 공격 반경, 추적선 등의 디버그 시각화를 켜고 끌 수 있는 토글 변수(bDrawDebug) 추가
- MeleeEnemyCharacter와 RangedEnemyCharacter에 총알 감지용 스피어 표시 토글 변수(bShowBulletDetectionSphere) 추가
- 토글 변수를 에디터와 블루프린트에서 편리하게 토글 가능하도록 구현
- 두 변수 모두 기본값은 모두 false로 설정하여, 디버그 시각화가 필요할 때만 활성화하도록 설계
- Tick 함수에서 bDrawDebug 값에 따라 조건부로 시야 범위 및 공격 반경 등 디버그 그리기 수행
- Enemy 캐릭터 BeginPlay에서 bShowBulletDetectionSphere 값에 따라 총알 감지 스피어 가시성 토글 처리
- AI 상태 및 감지 범위 확인을 위한 개발 및 테스트 편의성 향상 목적